### PR TITLE
Atualiza links expirados do postman

### DIFF
--- a/docs/payment-link/intro-payment-link.md
+++ b/docs/payment-link/intro-payment-link.md
@@ -24,7 +24,7 @@ Para saber mais informações sobre o Postman, acesse o site do [Postman](https:
 
 No Postman, é possível importar Collections que são um conjunto de exemplos de requisições que podem ser utilizadas para fins de teste. Para importá-la clique no botão abaixo:
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/5da5c26a20c0e076c7c2)
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/9885905-35876279-ecbf-4981-819b-602216b92e18?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9885905-35876279-ecbf-4981-819b-602216b92e18%26entityType%3Dcollection%26workspaceId%3D44da7bda-96eb-40ed-8bdb-010993538e5e)
 
 ### Ambiente de testes
 Para uma boa integração, disponibilizamos um ambiente de testes encontrado pela seguinte url: https://sandbox.evoluservices.com.

--- a/docs/remote-transaction/evoluservices-api/postman.md
+++ b/docs/remote-transaction/evoluservices-api/postman.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 Aqui está uma coleção de requisições de exemplo no Postman para ajudar a se
 familiarizar mais rapidamente com as nossas APIs.
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://elements.getpostman.com/redirect?entityId=9885905-e62a5909-53f0-4729-a071-41e39531ef3c&entityType=collection)
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/9885905-e62a5909-53f0-4729-a071-41e39531ef3c?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9885905-e62a5909-53f0-4729-a071-41e39531ef3c%26entityType%3Dcollection%26workspaceId%3D44da7bda-96eb-40ed-8bdb-010993538e5e)
 
 ### Importante
 


### PR DESCRIPTION
Foi verificado que os links dos de snippets do postman estavam expirados sendo necesário gerar um novo link